### PR TITLE
Fix SDK installs to --system Flatpak installation

### DIFF
--- a/app.devsuite.Manuals.json
+++ b/app.devsuite.Manuals.json
@@ -7,13 +7,16 @@
     "finish-args" : [
         "--allow=devel",
         "--device=dri",
-        "--filesystem=/var/lib/flatpak",
         "--filesystem=host:ro",
         "--filesystem=~/.local/share/flatpak",
+        "--filesystem=/var/lib/flatpak",
+        "--filesystem=/var/tmp",
         "--share=ipc",
         "--share=network",
         "--socket=fallback-x11",
         "--socket=wayland",
+        "--system-talk-name=org.freedesktop.PolicyKit1",
+        "--system-talk-name=org.freedesktop.Flatpak.SystemHelper",
         "--talk-name=org.freedesktop.Flatpak"
     ],
     "build-options" : {
@@ -110,20 +113,102 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/ostreedev/ostree.git",
-                    "tag" : "v2024.5"
+                    "tag" : "v2025.1"
+                }
+            ]
+        },
+        {
+            "name" : "polkit",
+            "config-opts" : [
+                "--disable-polkitd",
+                "--disable-man-pages",
+                "--disable-introspection",
+                "--disable-examples",
+                "--disable-gtk-doc",
+                "--disable-libelogind",
+                "--disable-libsystemd-login",
+                "--with-systemdsystemunitdir=no",
+                "--with-authdb=dummy",
+                "--with-authfw=none"
+            ],
+            "rm-configure" : true,
+            "build-options" : {
+                "env" : {
+                    "CFLAGS" : "-Wno-implicit-function-declaration"
+                }
+            },
+            "cleanup" : [
+                "/bin/*",
+                "/etc/pam.d",
+                "/etc/dbus-1",
+                "/share/dbus-1/system-services/*",
+                "/share/polkit-1",
+                "/lib/polkit-1"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://www.freedesktop.org/software/polkit/releases/polkit-0.116.tar.gz",
+                    "sha256" : "88170c9e711e8db305a12fdb8234fac5706c61969b94e084d0f117d8ec5d34b1"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "polkit-build-Add-option-to-build-without-polkitd.patch"
+                },
+                {
+                    "type" : "file",
+                    "path" : "polkit-autogen",
+                    "dest-filename" : "autogen.sh"
+                }
+            ]
+        },
+        {
+            "name": "bubblewrap",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dman=disabled",
+                "-Dselinux=disabled",
+                "-Dtests=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/projectatomic/bubblewrap/archive/refs/tags/v0.11.0.tar.gz",
+                    "sha256": "cfeeb15fcc47d177d195f06fdf0847e93ee3aa6bf46f6ac0a141fa142759e2c3"
+                }
+            ]
+        },
+        {
+            "name": "xdg-dbus-proxy",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dman=disabled",
+                "-Dtests=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/flatpak/xdg-dbus-proxy/archive/refs/tags/0.1.6.tar.gz",
+                    "sha256": "ee9c1d665f4e3b025a83d522d478ff7930070f2817fc2cb446db0dca93c990b1"
                 }
             ]
         },
         {
             "name" : "flatpak",
+            "buildsystem" : "meson",
             "config-opts" : [
-                "--disable-documentation",
-                "--disable-seccomp",
-                "--disable-sandboxed-triggers",
-                "--disable-system-helper",
-                "--with-curl",
-                "--with-system-install-dir=/var/lib/flatpak",
-                "--sysconfdir=/var/run/host/etc"
+                "-Ddocbook_docs=disabled",
+                "-Dseccomp=disabled",
+                "-Dsandboxed_triggers=false",
+                "-Dsystem_helper=enabled",
+                "-Dsystem_bubblewrap=bwrap",
+                "-Dsystem_dbus_proxy=xdg-dbus-proxy",
+                "-Dsystem_install_dir=/var/lib/flatpak",
+                "--sysconfdir=/var/run/host/etc",
+                "-Dman=disabled",
+                "-Dhttp_backend=curl",
+                "-Dsystemd=disabled",
+                "-Dtests=false"
             ],
             "cleanup" : [
                 "/bin/flatpak-bisect",
@@ -144,7 +229,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/flatpak/flatpak.git",
-                    "tag" : "1.14.5"
+                    "tag" : "1.16.0"
                 }
             ]
         },

--- a/fusermount-wrapper.sh
+++ b/fusermount-wrapper.sh
@@ -6,4 +6,4 @@ else
     FD_ARGS="--env=_FUSE_COMMFD=${_FUSE_COMMFD} --forward-fd=${_FUSE_COMMFD}"
 fi
 
-exec flatpak-spawn --host --forward-fd=1 --forward-fd=2 --forward-fd=3 $FD_ARGS fusermount "$@"
+exec flatpak-spawn --host --watch-bus $FD_ARGS fusermount "$@"

--- a/polkit-autogen
+++ b/polkit-autogen
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+gtkdocize --flavour no-tmpl
+autoreconf -if

--- a/polkit-build-Add-option-to-build-without-polkitd.patch
+++ b/polkit-build-Add-option-to-build-without-polkitd.patch
@@ -1,0 +1,132 @@
+From 1073a44277316348d40d86ecec908f1d4812f360 Mon Sep 17 00:00:00 2001
+From: Christian Hergert <chergert@redhat.com>
+Date: Mon, 27 May 2019 11:49:09 -0700
+Subject: [PATCH] flatpak: make polkit suitable for use within flatpak
+
+This is based on patches from Patrick Griffis with additional fixes
+to allow us to disable use of PAM within Flaptak.
+---
+ configure.ac                | 20 ++++++++++++++++----
+ src/Makefile.am             |  6 +++++-
+ src/polkitagent/Makefile.am |  5 +++++
+ test/Makefile.am            |  6 +++++-
+ 4 files changed, 31 insertions(+), 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 5cedb4e..729d78d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -79,11 +79,13 @@ PKG_CHECK_MODULES(GLIB, [gmodule-2.0 gio-unix-2.0 >= 2.30.0])
+ AC_SUBST(GLIB_CFLAGS)
+ AC_SUBST(GLIB_LIBS)
+ 
+-PKG_CHECK_MODULES(LIBJS, [mozjs-60])
++AS_IF([test x${enable_polkitd} = yes], [
++  PKG_CHECK_MODULES(LIBJS, [mozjs-60])
+ 
+-AC_SUBST(LIBJS_CFLAGS)
+-AC_SUBST(LIBJS_CXXFLAGS)
+-AC_SUBST(LIBJS_LIBS)
++  AC_SUBST(LIBJS_CFLAGS)
++  AC_SUBST(LIBJS_CXXFLAGS)
++  AC_SUBST(LIBJS_LIBS)
++])
+ 
+ EXPAT_LIB=""
+ AC_ARG_WITH(expat, [  --with-expat=<dir>      Use expat from here],
+@@ -236,6 +238,15 @@ if test "x$with_systemdsystemunitdir" != "xno"; then
+ fi
+ AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$systemdsystemunitdir"])
+ 
++dnl ---------------------------------------------------------------------------
++dnl - Disable polkitd when using library alone
++dnl ---------------------------------------------------------------------------
++
++AC_ARG_ENABLE([polkitd],
++              [AS_HELP_STRING([--disable-polkitd], [Do not build polkitd])],
++              [enable_polkitd=$enableval], [enable_polkitd=yes])
++AM_CONDITIONAL(BUILD_POLKITD, [test x${enable_polkitd} = yes])
++
+ dnl ---------------------------------------------------------------------------
+ dnl - User for running polkitd
+ dnl ---------------------------------------------------------------------------
+@@ -579,6 +590,7 @@ echo "
+         Session tracking:           ${SESSION_TRACKING}
+         PAM support:                ${have_pam}
+         systemdsystemunitdir:       ${systemdsystemunitdir}
++        polkitd:                    ${enable_polkitd}
+         polkitd user:               ${POLKITD_USER}"
+ 
+ if test "$have_pam" = yes ; then
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 09fc7b3..c6fe91b 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -1,5 +1,9 @@
+ 
+-SUBDIRS = polkit polkitbackend polkitagent programs
++SUBDIRS = polkit polkitagent programs
++
++if BUILD_POLKITD
++SUBDIRS += polkitbackend
++endif
+ 
+ if BUILD_EXAMPLES
+ SUBDIRS += examples
+diff --git a/src/polkitagent/Makefile.am b/src/polkitagent/Makefile.am
+index 49720db..633f9d4 100644
+--- a/src/polkitagent/Makefile.am
++++ b/src/polkitagent/Makefile.am
+@@ -79,6 +79,7 @@ libpolkit_agent_1_la_LIBADD =                               		\
+ 
+ libpolkit_agent_1_la_LDFLAGS = -export-symbols-regex '(^polkit_.*)'
+ 
++if !POLKIT_AUTHFW_NONE
+ libprivdir = $(prefix)/lib/polkit-1
+ libpriv_PROGRAMS = polkit-agent-helper-1
+ 
+@@ -113,6 +114,8 @@ polkit_agent_helper_1_LDFLAGS = 					\
+ 	$(AM_LDFLAGS)							\
+ 	$(NULL)
+ 
++endif # !POLKIT_AUTHFW_NONE
++
+ if HAVE_INTROSPECTION
+ 
+ girdir = $(INTROSPECTION_GIRDIR)
+@@ -142,6 +145,7 @@ include $(INTROSPECTION_MAKEFILE)
+ 
+ endif # HAVE_INTROSPECTION
+ 
++if !POLKIT_AUTHFW_NONE
+ # polkit-agent-helper-1 need to be setuid root because it's used to
+ # authenticate not only the invoking user, but possibly also root
+ # and/or other users.
+@@ -149,6 +153,7 @@ endif # HAVE_INTROSPECTION
+ install-data-hook:
+ 	-chown root $(DESTDIR)$(libprivdir)/polkit-agent-helper-1
+ 	-chmod 4755 $(DESTDIR)$(libprivdir)/polkit-agent-helper-1
++endif # !POLKIT_AUTHFW_NONE
+ 
+ EXTRA_DIST = polkitagentmarshal.list polkitagentenumtypes.h.template polkitagentenumtypes.c.template
+ CLEANFILES = $(gir_DATA) $(typelibs_DATA)
+diff --git a/test/Makefile.am b/test/Makefile.am
+index 59d0680..d43b0fe 100644
+--- a/test/Makefile.am
++++ b/test/Makefile.am
+@@ -1,7 +1,11 @@
+ 
+-SUBDIRS = mocklibc . polkit polkitbackend
++SUBDIRS = mocklibc . polkit
+ AM_CFLAGS = $(GLIB_CFLAGS)
+ 
++if BUILD_POLKITD
++SUBDIRS += polkitbackend
++endif
++
+ noinst_LTLIBRARIES = libpolkit-test-helper.la
+ libpolkit_test_helper_la_SOURCES = polkittesthelper.c polkittesthelper.h
+ libpolkit_test_helper_la_LIBADD = $(GLIB_LIBS)
+-- 
+2.21.0
+


### PR DESCRIPTION
Apparently during all the trimming down of build scripts for Flathub, installing to `--system` installations broke. This had to do with a number of things:

 * `system_helper` was disabled in Flatpak build which meant we didn't evne try the host
 * Polkit was lacking (needed for `system_helper`
 * Lack of `--filesystem=/var/tmp` meant the fusermount bits wouldn't work (thus session helper broken)

I don't remember having to do the `/var/tmp` thing in the past so it is very likely fallout from a more recent flatpak release.